### PR TITLE
Added version number

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0.3",
   "name": "ie10-viewport-bug-workaround",
   "description": "Bootstrap 3 support for Internet Explorer 10 in Windows 8 and Windows Phone 8",
   "keywords": [


### PR DESCRIPTION
In order to be able to get it to work with yarn the version number is required. Otherwise it throws errors about missing version number.